### PR TITLE
mobile format and ruleset selection fix

### DIFF
--- a/src/app/util/format-select/format.component.html
+++ b/src/app/util/format-select/format.component.html
@@ -1,8 +1,5 @@
 <div
   class="form-container"
-  [ngClass]="{
-    'full-screen-on-mobile': formatSelect.panelOpen,
-  }"
 >
   <mat-form-field
     class="w-full"

--- a/src/app/util/ruleset-select/ruleset.component.html
+++ b/src/app/util/ruleset-select/ruleset.component.html
@@ -1,8 +1,5 @@
 <div
   class="form-container"
-  [ngClass]="{
-    'full-screen-on-mobile': rulesetSelect.panelOpen,
-  }"
 >
   <mat-form-field
     class="w-full"


### PR DESCRIPTION
The issue seems to be with conditionally adding the `full-screen-on-mobile` class after clicking the format/ruleset selection form, which fills the entire screen with an empty div. Another thing i noticed is a bare `form-container` class with seemingly no CSS in the same div - maybe this was meant to be a different class? Nevertheless, just deleting these seems to fix the issue of not being able to select format/ruleset for now